### PR TITLE
Make focus-related test cases succeed in Firefox

### DIFF
--- a/tests/qunit/jquery.valueview/valueview.tests.testExpert.js
+++ b/tests/qunit/jquery.valueview/valueview.tests.testExpert.js
@@ -280,20 +280,21 @@ function testExpert( testDefinition ) {
 		);
 	} );
 
-	 expertCasesTestAndCleanup( 'focus', function( args, assert ) {
-		 try {
-			 args.expert.focus();
-		 } catch (e) {
-			 // Firefox does not support focusing elements that are not visible.
-			 assert.equal( e.name, 'NS_ERROR_FAILURE' );
-			 assert.equal( e.result, 0x80004005 );
-			 return;
-		 }
-		 assert.ok(
-			 true,
-			 'focus() has been called'
-		 );
-	 } );
+	expertCasesTestAndCleanup( 'focus', function( args, assert ) {
+		try {
+			args.expert.focus();
+		} catch( e ) {
+			assert.ok(
+				e.name === 'NS_ERROR_FAILURE' && e.result === 0x80004005,
+				'Unable to focus since browser requires element to be in the DOM.'
+			);
+			return;
+		}
+		assert.ok(
+			true,
+			'focus() has been called.'
+		);
+	} );
 
 	expertCasesMemberCallTest( 'blur' );
 

--- a/tests/qunit/jquery/jquery.fn.focusAt.tests.js
+++ b/tests/qunit/jquery/jquery.fn.focusAt.tests.js
@@ -64,11 +64,12 @@
 	var elemsCases = QUnit.cases( elemsCasesData );
 
 	elemsCases.test( 'Focusing with valid parameter', function( params, assert ) {
-		var positions = [ 0, 1, 4, 9, 9999, 'start', 'end', -1, -3, -9999 ];
+		var $dom = getDomInsertionTestViewport(),
+			positions = [ 0, 1, 4, 9, 9999, 'start', 'end', -1, -3, -9999 ];
 
 		$.each( positions, function( i, pos ) {
 			// Put element in DOM, since Firefox expects this
-			$( 'body' ).append( params.elem );
+			$dom.append( params.elem );
 			assert.ok(
 				params.elem.focusAt( pos ),
 				'focusAt takes "' + pos + '" as a valid position for the element'
@@ -99,11 +100,15 @@
 		}
 
 		try {
-			elem.focusAt( 0 );
-		} catch (e) {
-			// Firefox does not support focusing elements that are not visible.
-			assert.equal( e.name, 'NS_ERROR_FAILURE' );
-			assert.equal( e.result, 0x80004005 );
+			assert.ok(
+				elem.focusAt( 0 ),
+				'Can call focusAt on element not in DOM yet.'
+			);
+		} catch( e ) {
+			assert.ok(
+				e.name === 'NS_ERROR_FAILURE' && e.result === 0x80004005,
+				'Unable to focus since browser requires element to be in the DOM.'
+			);
 			return;
 		}
 


### PR DESCRIPTION
Firefox throws an exception if an element to be focused is not visible or not
in DOM at all. This patch fixes three test cases: two by accepting the
exception as valid, one by making sure the element is visible.

Change by Adrian Lang. Ported from https://gerrit.wikimedia.org/r/#/c/105945/
