### PR TITLE
Fix inputAutoExpand tests

### DIFF
--- a/lib/jquery/jquery.inputautoexpand.js
+++ b/lib/jquery/jquery.inputautoexpand.js
@@ -423,8 +423,7 @@
 					top: '-9999px',
 					left: '-9999px',
 					right: 'auto',
-					bottom: 'auto',
-					wordWrap: 'break-word'
+					bottom: 'auto'
 				} );
 		}
 
@@ -464,7 +463,8 @@
 			'textTransform',
 			'wordSpacing',
 			'textIndent',
-			'overflowY'
+			'overflowY',
+			'wordWrap'
 		];
 
 		for( var i = 0; i < stylesToCopy.length; i++ ) {
@@ -474,8 +474,7 @@
 		// styles not being influenced by copying styles
 		$to.css( {
 			overflow: 'hidden',
-			overflowY: 'hidden',
-			wordWrap: 'break-word'
+			overflowY: 'hidden'
 		} );
 	}
 

--- a/tests/lib/jquery/jquery.inputautoexpand.tests.js
+++ b/tests/lib/jquery/jquery.inputautoexpand.tests.js
@@ -190,6 +190,7 @@
 		// Init plugin before measuring the initial height since the plugin will shrink the textarea
 		// to one line first:
 		$textarea.inputautoexpand( { expandWidth: false, expandHeight: true } );
+		$textarea.css( 'word-wrap', 'normal' );
 
 		var initialHeight = Math.ceil( $textarea.height() ),
 			previousHeight,


### PR DESCRIPTION
The failing test asserted that inserting a longer line would not affect the
height of an inputAutoExpand textarea. However, the word-wrap setting lead to
the line wrapping around.
