### PR TITLE
Make StringValue expert's _getRawValue return null for empty strings

### DIFF
--- a/src/experts/StringValue.js
+++ b/src/experts/StringValue.js
@@ -67,7 +67,7 @@
 		 * @see jQuery.valueview.Expert._getRawValue
 		 */
 		_getRawValue: function() {
-			return this._newValue === false ? this.$input.val() : this._newValue;
+			return ( this._newValue === false ? this.$input.val() : this._newValue ) || null;
 		},
 
 		/**


### PR DESCRIPTION
The documentation for _getRawValue in jQuery.valueview.Expert states that
_getRawValue "[r]eturns null for an empty value".
