### PR TITLE
Remove one animation, make other durations user-definable

### DIFF
--- a/lib/jquery.ui/jquery.ui.inputextender.js
+++ b/lib/jquery.ui/jquery.ui.inputextender.js
@@ -152,14 +152,14 @@
 					clearTimeout( self._animationTimeout );
 					self._animationTimeout = setTimeout( function() {
 						self.showExtension();
-					}, 250 );
+					}, 250 ); //TODO: Fixed values can't be changed nor turned off
 				}
 			} )
 			.on( 'blur.' + this.widgetName, function( event ) {
 				clearTimeout( self._animationTimeout );
 				self._animationTimeout = setTimeout( function() {
 					self.hideExtension();
-				}, 250 );
+				}, 250 ); //TODO: Fixed values can't be changed nor turned off
 			} )
 			.on( 'keydown.' + this.widgetName, function( event ) {
 				if( event.keyCode === $.ui.keyCode.ESCAPE ) {
@@ -355,7 +355,7 @@
 				'extensionexpansion',
 				'fadeIn',
 				{
-					duration: 150,
+					duration: 150, //TODO: Fixed values can't be changed nor turned off
 					complete: function() {
 						if( $.isFunction( callback ) ) {
 							callback();
@@ -376,7 +376,7 @@
 				'extensionremoval',
 				'fadeOut',
 				{
-					duration: 150,
+					duration: 150, //TODO: Fixed values can't be changed nor turned off
 					complete: function() {
 						inputExtendersWithVisibleExtension.remove( self );
 						if( $.isFunction( callback ) ) {

--- a/lib/jquery.ui/jquery.ui.listrotator.js
+++ b/lib/jquery.ui/jquery.ui.listrotator.js
@@ -107,7 +107,7 @@
 			},
 			animation: {
 				margins: ['-15px', '15px'],
-				duration: 150
+				duration: 150 //TODO: Fixed values can't be changed nor turned off
 			},
 			deferInit: false,
 			messages: {
@@ -581,7 +581,7 @@
 		 * Shows the drop-down menu.
 		 */
 		_showMenu: function() {
-			this.$menu.slideDown( this.options.animation.duration );
+			this.$menu.show();
 
 			function flip( string ) {
 				var segments = $.map( string.split( ' ' ), function( segment ) {
@@ -606,7 +606,7 @@
 		 * Hides the drop-down menu.
 		 */
 		_hideMenu: function() {
-			this.$menu.slideUp( this.options.animation.duration );
+			this.$menu.hide();
 			this.activate();
 		},
 

--- a/lib/jquery.ui/jquery.ui.toggler.js
+++ b/lib/jquery.ui/jquery.ui.toggler.js
@@ -148,7 +148,7 @@
 			this.$toggleIcon.removeClass( iconClass + 'e ' + iconClass + 's ' + iconClass + 'w '
 				+ this.widgetBaseClass + '-icon3dtrans' );
 			// Add classes displaying rotated icon. If CSS3 transform is available, use it:
-			if( !browserSupportsTransform ) {
+			if( !browserSupportsTransform || !$.speed().duration ) {
 				this.$toggleIcon.addClass( iconClass + ( visible ? 's' : dir ) );
 			} else {
 				this.$toggleIcon.addClass( iconClass + 's '


### PR DESCRIPTION
jQuery provides some default animation duration constants that
can be changed or turned off by the user if he want's. Constant
ms times can not.

This removes only one animation when the drop-down menu to select
(for example) the calendar model is opened and closed. It does not
make much sense to animate this since no other similar drop-down
is animated.
