### PR TITLE
Fix type annotation in CommonsMediaType expert

### DIFF
--- a/src/experts/CommonsMediaType.js
+++ b/src/experts/CommonsMediaType.js
@@ -52,7 +52,7 @@
 		 */
 		_staticExpertOptions: {
 			/**
-			 * @param {time.Time|null} currentRawValue
+			 * @param {string|null} currentRawValue
 			 * @param {jQuery.valueview.ViewState} viewState
 			 * @param {jQuery.valueview.MessageProvider} messageProvider
 			 */


### PR DESCRIPTION
That's always a string or null.
