### PR TITLE
Reuse DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Other methods an Expert needs to provide:
 
 ## Release notes
 
+### 0.4.2 (2014-03-27)
+
+* Use DOM children of the ValueView as formatted value on initialization
+* Don't parse and format a value if it did not change
+
 ### 0.4.1 (2014-03-26)
 
 * Require data-values/javascript 0.4

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.4.1' );
+define( 'VALUEVIEW_VERSION', '0.4.2' );
 
 /**
  * @deprecated

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -169,7 +169,7 @@ $.widget( 'valueview.valueview', PARENT, {
 		} );
 
 		// Set initial value if provided in options:
-		this.value( this.option( 'value' ) || null );
+		this._initValue( this.option( 'value' ) || null );
 
 		if( this.option( 'autoStartEditing' ) && this.isEmpty() ) {
 			// If no data value is represented, offer UI to build one.
@@ -342,6 +342,17 @@ $.widget( 'valueview.valueview', PARENT, {
 		this._setValue( value );
 	},
 
+	_initValue: function( value ) {
+		var formattedValue = this.element.html();
+		if( !formattedValue ) {
+			return this.value( value );
+		} else {
+			this._value = value;
+			this._formattedValue = formattedValue;
+			this._updateExpertConstructor();
+		}
+	},
+
 	/**
 	 * Sets the value internally and triggers the validation process on the new value, will also
 	 * make sure that the new value will be displayed.
@@ -357,6 +368,11 @@ $.widget( 'valueview.valueview', PARENT, {
 		) {
 			throw new Error( 'Instance of dataValues.DataValue required for setting a value' );
 		}
+
+		if( this._value && this._value.toJSON && JSON.stringify( value.toJSON() ) === JSON.stringify( this._value.toJSON() ) ) {
+			return;
+		}
+
 		this._value = value;
 		this._updateExpertConstructor(); // new value, new expert might be needed
 


### PR DESCRIPTION
If the ValueView element has children, assume they are the formatted value and just keep them instead of formatting the value.

Also, don't do anything on _setValue if value did not change.
