### PR TITLE
Don't throw an error when setting null value on a ValueView

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Other methods an Expert needs to provide:
 * Updated DataValuesJavaScript dependency to version 0.5.0.
 * Removed setting default formatter provider/store and parser provider/store of jQuery.valueView in mw.ext.valueView since no defaults are provided by DataValuesJavaScript as of version 0.5.0.
 * Removed mw.ext.valueView module.
+* Fixed ValueView to again support setting value to null
 
 ### 0.4.2 (2014-03-27)
 

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -369,7 +369,7 @@ $.widget( 'valueview.valueview', PARENT, {
 			throw new Error( 'Instance of dataValues.DataValue required for setting a value' );
 		}
 
-		if( this._value && this._value.toJSON && JSON.stringify( value.toJSON() ) === JSON.stringify( this._value.toJSON() ) ) {
+		if( this._value && value && JSON.stringify( value.toJSON() ) === JSON.stringify( this._value.toJSON() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Since DataValues have to have a `toJSON` method and `_value` and `value` are guaranteed to be null or a DataValue, the check for `toJSON` is not needed. However, we definitely have to check whether `value` actually is null.
