### PR TITLE
Remove duplicate array key

### DIFF
--- a/tests/src/resources.php
+++ b/tests/src/resources.php
@@ -55,15 +55,6 @@ return call_user_func( function() {
 			),
 		),
 
-		'jquery.valueview.tests.MockExpert' => $moduleTemplate + array(
-			'scripts' => array(
-				'jquery.valueview.tests.MockExpert.js',
-			),
-			'dependencies' => array(
-				'jquery.valueview.Expert',
-			),
-		),
-
 		'jquery.valueview.tests.MockViewState' => $moduleTemplate + array(
 			'scripts' => array(
 				'jquery.valueview.tests.MockViewState.js',


### PR DESCRIPTION
Obviously a copy and paste error, found by the PHPStorm code analysis.
