### PR TITLE
Add resource dependencies for jquery.ui.suggester

### DIFF
--- a/lib/resources.php
+++ b/lib/resources.php
@@ -168,7 +168,9 @@ return call_user_func( function() {
 			),
 			'dependencies' => array(
 				'jquery',
+				'jquery.ui.core',
 				'jquery.ui.ooMenu',
+				'jquery.ui.position',
 				'jquery.ui.widget',
 			),
 		),


### PR DESCRIPTION
jquery.ui.core and jquery.ui.position are needed for
the suggester to work on non-entity namespaces in
the search box.

Bug: 66257
