### PR TITLE
Let me set toggler options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Other methods an Expert needs to provide:
 ### 0.6.2 (dev)
 
 * Support editing arbitrary precisions for GlobeCoordinates
+* Added support for options in the ui.toggler widget.
 
 ### 0.6.1 (2014-06-09)
 

--- a/lib/jquery.ui/jquery.ui.toggler.js
+++ b/lib/jquery.ui/jquery.ui.toggler.js
@@ -102,6 +102,7 @@
 					self.options.$subject.stop().animateWithEvent(
 						'togglerstatetransition',
 						'slideToggle',
+						self.options,
 						function( animationEvent ) {
 							self._trigger( 'animation', animationEvent );
 						}


### PR DESCRIPTION
... like every other widget does. The strange thing is that there actually _are_ options but they are not passed for some reason.

Required for https://gerrit.wikimedia.org/r/#/c/138654/.
