### PR TITLE
Client link item feature requires z-index

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -4,8 +4,9 @@
  */
 
 .ui-suggester-list {
-	border-color: #C9C9C9;
 	background: white;
+	border-color: #C9C9C9;
+	z-index: 2000; /* required for the client link feature, the dialog is at ~1002 */
 }
 
 .ui-suggester-list .ui-state-hover {

--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -492,9 +492,11 @@
 		 *         - {string}
 		 */
 		_getSuggestions: function( term ) {
-			return ( $.isArray( this.options.source ) )
-				? this._getSuggestionsFromArray( term, this.options.source )
-				: this.options.source( term );
+			if ( typeof this.options.source === 'function' ) {
+				return this.options.source( term );
+			}
+
+			return this._getSuggestionsFromArray( term, this.options.source );
 		},
 
 		/**


### PR DESCRIPTION
Both this patch and https://gerrit.wikimedia.org/r/#/c/139369/ are needed to fix the site link selector on the client.
