### PR TITLE
Revert wrongly placed CSS

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -7,9 +7,6 @@
 	background: white;
 	border-color: #C9C9C9;
 	min-width: 8em;
-	/* required for the client link feature, the dialog is at ~1002. also needs
-	 * to be above .ui-inputextender-extension and .ui-listrotator-menu */
-	z-index: 2000;
 }
 
 .ui-suggester-list .ui-state-hover {


### PR DESCRIPTION
The constant `2000` is an ugly hack that doesn't belong here. The z-index this number depends on is on the client. The component should not guess what the z-indexes on the client may be. That's just wrong. This needs a fix on the client, see https://gerrit.wikimedia.org/r/#/c/139396/.
