### PR TITLE
Don't reset the input value on suggester blur

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -201,9 +201,6 @@
 			.appendTo( 'body' );
 
 			$( ooMenu )
-			.on( 'blur.suggester', function() {
-				self.element.val( self._term );
-			} )
 			.on( 'selected.suggester', function( event, item ) {
 				if( item instanceof $.ui.ooMenu.Item && !( item instanceof $.ui.ooMenu.CustomItem ) ) {
 					self._term = item.getValue();


### PR DESCRIPTION
this._term can be an old value which might significantly
differ differ from the current form value.

This causes:
If one adds a sitelink, quickly pastes a page title
and hits enter this code block will set the value of the
input back to the one before the paste (empty string).
