### PR TITLE
Revert class name back to "valueview"

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Other methods an Expert needs to provide:
 * Added expert for MonolingualText values.
 * Support editing arbitrary precisions for GlobeCoordinates.
 * Added support for options in the ui.toggler widget.
+* Fixed wrong valueview-valueview-... class names after jQuery update.
 * Fixed RTL related bug in ui.suggester.
 
 ### 0.6.2 (2014-06-16)

--- a/src/jquery.valueview.valueview.js
+++ b/src/jquery.valueview.valueview.js
@@ -92,11 +92,6 @@ function expertProxy( fnName ) {
  */
 $.widget( 'valueview.valueview', PARENT, {
 	/**
-	 * @see jQuery.Widget
-	 */
-	widgetBaseClass: 'valueview', // jQuery.widget would set this to 'valueview-valueview'
-
-	/**
 	 * Current, accepted value. Might be "behind" the expert's raw value until the raw value gets
 	 * parsed and the parsed result set as the new accepted value.
 	 * @type dv.DataValue|null
@@ -943,5 +938,9 @@ $.widget( 'valueview.valueview', PARENT, {
 		return {};
 	}
 } );
+
+// We have to override this here because $.widget sets it no matter what's in
+// the prototype
+$.valueview.valueview.prototype.widgetBaseClass = 'valueview';
 
 }( dataValues, util, jQuery, valueFormatters, valueParsers ) );


### PR DESCRIPTION
Constructing widgets works different in the currently used version of jQuery. Looks like the option is ignored now since `this.widgetBaseClass` started to return `valueview-valueview`. Which broke most gadgets on wikidata.org.

~~I'm not 100% sure if this is a proper fix. "Somebody" needs to run the browser tests before this is merged. ;-)~~

~~Note: The same problem may be present in the RankSelector widget. We should check this.~~ Seems to be ok.

[Bug: 66883](https://bugzilla.wikimedia.org/show_bug.cgi?id=66883)
