### PR TITLE
Change option from "lang" to "valuelang"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Other methods an Expert needs to provide:
 ## Release notes
 
 ### 0.6.4 (dev)
+* Changed MonolingualText option from "lang" to "valuelang".
 * Added setLink() function to jQuery.ui.ooMenu.CustomItem prototype allowing dynamical updates of the link target.
 * Removed default "javascript:void(0);" link target of jQuery.ui.ooMenu.CustomItem instances.
 

--- a/src/experts/MonolingualText.js
+++ b/src/experts/MonolingualText.js
@@ -39,7 +39,7 @@
 		valueCharacteristics: function() {
 			var options = {};
 			if( this._languageSelector ) {
-				options.lang = this._languageSelector.getValue();
+				options.valuelang = this._languageSelector.getValue();
 			}
 			return options;
 		},


### PR DESCRIPTION
This solves the issue that a monolingual text with no language selected silently defaults to "en".

To understand this patch you need to understand that the existing "lang" option does have a different meaning and should not be reused for the language selection needed by monolingual.

The "lang" option is supposed to default to something (preferable the users UI language). For example, if the user enters a date we assume what he types is in his language. He can not (and should not) choose a language before he can enter a date, right?

But that's what's needed here. What I call "valuelang" now (please suggest a better name if you have an idea) is supposed to have no default value. The user _must_ pick a language.

Needed by https://gerrit.wikimedia.org/r/#/c/143328.
