### PR TITLE
Restrict select to left click

### DIFF
--- a/lib/jquery.ui/jquery.ui.ooMenu.js
+++ b/lib/jquery.ui/jquery.ui.ooMenu.js
@@ -184,8 +184,10 @@ $.widget( 'ui.ooMenu', {
 		.on( 'mouseleave.ooMenu', function() {
 			self.deactivate();
 		} )
-		.on( 'mousedown.ooMenu', function( event ) {
-			self.select( event );
+		.on( 'mousedown.ooMenu', function( e ) {
+			if ( !( e.which !== 1 || e.altKey || e.ctrlKey || e.shiftKey || e.metaKey ) ) {
+				self.select( event );
+			}
 		} );
 
 		$item.appendTo( this.element );


### PR DESCRIPTION
Selecting something in a menu (no matter what it contains) should only be possible with a basic left mouse click. Not middle click. Not right click. Not Ctrl+click and so on.

The line is copied from core/resources/src/jquery/jquery.suggestions.js, which means it should be well tested and cover all cases.

This does not solve all problems (the menu still closes because of focus loss) but is a base for more.
