### PR TITLE
Never underline ooMenu/suggester contents

### DIFF
--- a/lib/jquery.ui/jquery.ui.ooMenu.css
+++ b/lib/jquery.ui/jquery.ui.ooMenu.css
@@ -18,6 +18,7 @@
 
 .ui-ooMenu li a {
 	display: block;
+	text-decoration: none;
 }
 
 .ui-ooMenu li.ui-ooMenu-customItem-action {


### PR DESCRIPTION
This is relevant because we have a "Link underlining: always" setting in MediaWiki core. In my opinion it's correct to always disable underlining in all menus based on this class.

[Bug: 66434](https://bugzilla.wikimedia.org/show_bug.cgi?id=66434)
