### PR TITLE
Never underline sugester menu items

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -29,6 +29,7 @@
 
 .ui-suggester-list .ui-ooMenu-item a {
 	padding: 0 0.2em;
+	text-decoration: none;
 }
 
 .ui-suggester-list .ui-ooMenu-item a.ui-state-hover,


### PR DESCRIPTION
This is a real problem because core does have a setting to always underline links. Even if the elements in the suggesters are links (sometimes with a href, sometimes not) they should never ever be underlined.
