### PR TITLE
Add fallbacks for critical messages

### DIFF
--- a/src/ExpertExtender/ExpertExtender.Toggler.js
+++ b/src/ExpertExtender/ExpertExtender.Toggler.js
@@ -43,7 +43,7 @@
 		init: function( $extender ) {
 			this.$toggler
 				.addClass( 'valueview-expertextender-advancedtoggler' )
-				.text( this._messageProvider.getMessage( 'valueview-expert-advancedadjustments' ) );
+				.text( this._messageProvider.getMessage( 'valueview-expert-advancedadjustments' ) || 'more' );
 			$extender.append( this.$toggler );
 		},
 

--- a/src/experts/TimeInput.js
+++ b/src/experts/TimeInput.js
@@ -103,7 +103,7 @@
 		_options: {
 			messages: {
 				'valueview-expert-timeinput-precision': 'Precision',
-				'valueview-expert-timeinput-calendar': 'Calendar',
+				'valueview-expert-timeinput-calendar': 'Calendar'
 			}
 		},
 
@@ -173,7 +173,7 @@
 		$.each( timeSettings.calendarnames, function( calendarKey, calendarTerms ) {
 			var label = messageProvider.getMessage(
 				'valueview-expert-timevalue-calendar-' + calendarTerms[0].toLowerCase()
-			);
+			) || calendarTerms[0];
 			calendarValues.push( { value: calendarTerms[0], label: label } );
 		} );
 		return calendarValues;


### PR DESCRIPTION
This is not a fix for bug 68033.

But it's good to have fallbacks for the most critical messages in case something is wrong.
- The "more" message is the message next to the expand arrow in all experts.
- The calendar model can very easily show the untranslated calendar model name.

In both cases the alternative was to show "null" which is not helpful, doesn't show up in any log but makes the UI unusable for no good reason.

[Bug: 68033](https://bugzilla.wikimedia.org/show_bug.cgi?id=68033)
