### PR TITLE
Improve suggester color and width styles

### DIFF
--- a/lib/jquery.ui/jquery.ui.ooMenu.css
+++ b/lib/jquery.ui/jquery.ui.ooMenu.css
@@ -6,7 +6,6 @@
 	border: 1px solid #C9C9C9;
 	list-style: none;
 	margin: 0;
-	min-width: 8em;
 }
 
 .ui-ooMenu li {
@@ -18,9 +17,7 @@
 }
 
 .ui-ooMenu li a {
-	color: #000;
 	display: block;
-	text-decoration: none;
 }
 
 .ui-ooMenu li.ui-ooMenu-customItem-action {

--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -6,6 +6,7 @@
 .ui-suggester-list {
 	background: white;
 	border-color: #C9C9C9;
+	min-width: 8em;
 	/* required for the client link feature, the dialog is at ~1002. also needs
 	 * to be above .ui-inputextender-extension and .ui-listrotator-menu */
 	z-index: 2000;
@@ -28,7 +29,9 @@
 }
 
 .ui-suggester-list .ui-ooMenu-item a {
+	color: black;
 	padding: 0 0.2em;
+	text-decoration: none;
 }
 
 .ui-suggester-list .ui-ooMenu-item a.ui-state-hover,


### PR DESCRIPTION
- Removes the blue color from the items in the suggester. The same is done in core/resources/src/mediawiki/mediawiki.searchSuggest.css.
- Adds a basic min-width to make sure click-regions always have a decent size. The `8em` is copied from core/resources/lib/oojs-ui/oojs-ui.css.
- Reverts ~~#84~~ #83. It became obsolete the moment ~~#83~~ #84 finally got merged after two weeks.

[Bug: 66435](https://bugzilla.wikimedia.org/show_bug.cgi?id=66435)
