### PR TITLE
Fix black colored text in suggestions when activated with keydown

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -25,7 +25,7 @@
 	position: absolute;
 }
 
-.ui-suggester-list .ui-ooMenu-item a {
+.ui-suggester-list a {
 	color: black;
 	padding: 0 0.2em;
 	text-decoration: none;


### PR DESCRIPTION
bug also happens simply when typing to add a new site link, with no keydown.

Fix appears to be to apply color: black only to  .ui-suggester-list a
and not to .ui-suggester-list .ui-ooMenu-item a

[Bug: 68386](https://bugzilla.wikimedia.org/show_bug.cgi?id=68386)
