### PR TITLE
Remove irrelevant ooMenu selectors

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.css
+++ b/lib/jquery.ui/jquery.ui.suggester.css
@@ -30,8 +30,3 @@
 	padding: 0 0.2em;
 	text-decoration: none;
 }
-
-.ui-suggester-list a.ui-state-hover,
-.ui-suggester-list a.ui-state-active {
-	margin: 0;
-}


### PR DESCRIPTION
I really wonder why a active/focus/hover state should reset a margin? Wouldn't this makes stuff jump around? The only hint I could find is in core/resources/lib/jquery.ui/themes/smoothness/jquery.ui.menu.css:

``` CSS
.ui-menu .ui-menu-item a.ui-state-focus,
.ui-menu .ui-menu-item a.ui-state-active { font-weight: normal; margin: -1px; }
```

I guess the `0` rule was added to override the `-1px`. But it looks like this was dropped long ago from jQuery. And it's irrelevant anyway since we don't use the `.ui-menu-item` class any more.

An other reason to remove this is that the `.ui-ooMenu-item` selector refers to a class set by it's parent component when relying on it's own class name should be enough. See #89.
