### PR TITLE
Only close a suggester if it's open

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -549,6 +549,10 @@
 		 * Hides the suggester menu.
 		 */
 		_close: function() {
+			if( !this.options.menu.element.is( ':visible' ) ) {
+				return;
+			}
+
 			this.options.menu.deactivate();
 			this.options.menu.element.hide();
 


### PR DESCRIPTION
The old behaviour caused problems with Wikibase client's linkItem: The selected page disappeared once the user clicked on anything (including the submit button).
