### PR TITLE
Boost exact matches in suggestions

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -510,12 +510,28 @@
 		 *         - {string}
 		 */
 		_getSuggestionsFromArray: function( term, source ) {
-			var deferred = $.Deferred();
-
-			var matcher = new RegExp( this._escapeRegex( term ), 'i' );
+			var self = this,
+				deferred = $.Deferred(),
+				regex = this._escapeRegex( term ),
+				matcher = new RegExp( regex, 'i' ),
+				boosters = [
+					new RegExp( '\\(' + regex + '\\)', 'i' ),
+					new RegExp( '\\(' + regex + '-', 'i' ),
+					new RegExp( '^' + regex, 'i' ),
+					new RegExp( '\\(' + regex, 'i' )
+				];
 
 			deferred.resolve( $.grep( source, function( item ) {
 				return matcher.test( item );
+			} ).sort( function( a, b ) {
+				for ( var i = 0; i < boosters.length; i++ ) {
+					var boostA = boosters[i].test( a ),
+						boostB = boosters[i].test( b );
+					if ( boostA !== boostB ) {
+						return boostB - boostA;
+					}
+				}
+				return self._localeCompare( a, b );
 			} ), term );
 
 			return deferred.promise();
@@ -529,6 +545,12 @@
 		 */
 		_escapeRegex: function( value ) {
 			return value.replace( /[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&' );
+		},
+
+		_localeCompare: function( a, b ) {
+			return a.localeCompare
+				? a.localeCompare( b )
+				: ( a.toUpperCase() < b.toUpperCase() ? -1 : 1 );
 		},
 
 		/**

--- a/src/ExpertExtender/ExpertExtender.LanguageSelector.js
+++ b/src/ExpertExtender/ExpertExtender.LanguageSelector.js
@@ -98,7 +98,7 @@
 		 */
 		getValue: function() {
 			return this._inverseLanguagesMap ? this._inverseLanguagesMap[ this.$selector.val() ] : this.$selector.val();
-		},
+		}
 	} );
 
 	function getLanguagesMaps( getMsg ) {


### PR DESCRIPTION
This orders the suggestions into five groups:
1. Exact matches in brackets, e.g. when searching for "foo", `Bar (foo)` will be shown first.
2. Exact prefixes in brackets, e.g. `Bar (foo-bar)` (yes, this is a little optimization for the special case of languages with sub-languages).
3. Prefixes, e.g. `Fooxyz (xyz)`.
4. Prefixes in brackets, e.g. `Bar (fooxyz)`.
5. Whatever is left, e.g. `Xyzfoo (xyz)`.

Ordering inside the groups will be alphabetical.

[Bug: 67395](https://bugzilla.wikimedia.org/show_bug.cgi?id=67395)
