### PR TITLE
$.ui.suggester: Issue "error" event when gathering suggestions fails

### DIFF
--- a/lib/jquery.ui/jquery.ui.suggester.js
+++ b/lib/jquery.ui/jquery.ui.suggester.js
@@ -74,6 +74,13 @@
  *        Triggered when the suggester's value has changed.
  *        - {jQuery.Event}
  *
+ * @event error
+ *        Triggered whenever an error occurred while gathering suggestions. This may happen only
+ *        when using a function as source. The {string} parameter is forwarded from the rejected
+ *        promise returned by the source function.
+ *        - {jQuery.Event}
+ *        - {string}
+ *
  * @dependency jQuery.ui.ooMenu
  * @dependency jQuery.ui.position
  */
@@ -419,7 +426,7 @@
 			} )
 			.fail( function( message ) {
 				self.element.addClass( 'ui-suggester-error' );
-				// TODO: Display error message.
+				self._trigger( 'error', null, [message] );
 			} )
 			.always( function() {
 				if( --self._pending === 0 ) {
@@ -506,8 +513,7 @@
 		 *         Resolved parameters:
 		 *         - {string[]} suggestions
 		 *         - {string} requestTerm
-		 *         Rejected parameters:
-		 *         - {string}
+		 *         Promise may not be rejected.
 		 */
 		_getSuggestionsFromArray: function( term, source ) {
 			var deferred = $.Deferred();

--- a/tests/lib/jquery.ui/jquery.ui.suggester.tests.js
+++ b/tests/lib/jquery.ui/jquery.ui.suggester.tests.js
@@ -166,4 +166,43 @@
 		} );
 	} );
 
+	QUnit.test( 'Error', 2, function( assert ) {
+		var $suggester = newTestSuggester( {
+				source: function( term ) {
+					var deferred = new $.Deferred();
+					return deferred.reject( 'error string' ).promise();
+				}
+			} ),
+			suggester = $suggester.data( 'suggester' );
+
+		$suggester.on( 'suggestererror', function( event, errorString ) {
+			assert.equal(
+				errorString,
+				'error string',
+				'Validated expected error string.'
+			);
+		} );
+
+		$suggester.val( 'a' );
+
+		QUnit.stop();
+
+		suggester.search()
+		.done( function( suggestions ) {
+			assert.ok(
+				false,
+				'Searching was successful although it should have failed.'
+			);
+		} )
+		.fail( function() {
+			assert.ok(
+				true,
+				'Searching failed as expected.'
+			);
+		} )
+		.always( function() {
+			QUnit.start();
+		} );
+	} );
+
 }( jQuery, QUnit ) );


### PR DESCRIPTION
Instead of injecting another component to display the error message, the responsibility to display an error is passed on to parent component(s).
