### PR TITLE
Scroll ooMenu to top on refresh

### DIFF
--- a/lib/jquery.ui/jquery.ui.ooMenu.js
+++ b/lib/jquery.ui/jquery.ui.ooMenu.js
@@ -116,6 +116,7 @@ $.widget( 'ui.ooMenu', {
 	 */
 	_refresh: function() {
 		this.element.empty();
+		this.element.scrollTop( 0 );
 		for( var i = 0; i < this.options.items.length; i++ ) {
 			this._appendItem( this.options.items[i] );
 		}


### PR DESCRIPTION
Steps to reproduce:
- Edit the language of a monolingual value.
- Type "e".
- Scroll down in the list of the suggested languages.
- Select the "e" and type "d" instead.
- The scroll position sticks but shouldn't.
