### PR TITLE
Sort language names alphabetically

### DIFF
--- a/src/ExpertExtender/ExpertExtender.LanguageSelector.js
+++ b/src/ExpertExtender/ExpertExtender.LanguageSelector.js
@@ -54,10 +54,14 @@
 		 */
 		init: function( $extender ) {
 			if( this._languagesMap ) {
+				var source = $.map( this._languagesMap, function( language ) {
+					return language;
+				} );
+				if( ''.localeCompare ) {
+					source.sort( function( a, b ) { return a.localeCompare( b ); } );
+				}
 				this.$selector.languagesuggester( {
-					source: $.map( this._languagesMap, function( language ) {
-						return language;
-					} ),
+					source: source,
 					change: this._onValueChange
 				} );
 			} else {


### PR DESCRIPTION
Currently the order is basically undefined because `_languagesMap` is an object.

However, in browsers that do not support `localeCompare` we rely on the order of the `uls.data.languages` object. This is better than plain ASCII ordering.
