### PR TITLE
Fix broken precision auto detection

### DIFF
--- a/src/experts/GlobeCoordinateInput.js
+++ b/src/experts/GlobeCoordinateInput.js
@@ -35,7 +35,7 @@
 			function( newPrecisionLevel ) {
 				self._viewNotifier.notify( 'change' );
 			},
-			function(){
+			function() {
 				var value = self.viewState().value();
 				if( !value ) {
 					return value;
@@ -124,7 +124,7 @@
 	 * @return {number}
 	 */
 	function roundPrecision( precision ) {
-		return parseFloat( precision.toPrecision(4) );
+		return parseFloat( precision.toPrecision( 6 ) );
 	}
 
 	/**
@@ -136,14 +136,12 @@
 	 * @return {number|null}
 	 */
 	function getPrecisionSetting( precision ) {
-		var rounded,
-			actualPrecision = null,
+		var actualPrecision = null,
 			roundedPrecision = roundPrecision( precision );
 
 		$.each( PRECISIONS, function( i, precision ) {
-			rounded = roundPrecision( precision );
-			if( rounded === roundedPrecision ) {
-				actualPrecision = precision;
+			if( roundPrecision( precision ) === roundedPrecision ) {
+				actualPrecision = roundedPrecision;
 				return false;
 			}
 		} );


### PR DESCRIPTION
We still have code that uses a constant (`0.0000001`) to check if a precision is known (see globeCoordinate.Formatter). The code in this pull request uses `toPrecision` instead (which is fine, I even reviewed and merged this, I think). This works perfectly fine for all precisions except for 1 / 60 which is rounded to 0.01667. `( 1 / 60 ).toPrecision( 4 ) - 1 / 60 < 0.0000001` is false but with `toPrecision( 6 )` it's true.

I hope this does not break other things. @adrianlang?

``` js
[ 10, 1, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001,
    1 / 60, 1 / 3600, 1 / 36000, 1 / 360000, 1 / 3600000 ].map( function( a ) {
    return a.toPrecision( 4 ) - a < 0.0000001 ? 'ok' : a;
} ).join( ', ' )
```

[Bug 64820](https://bugzilla.wikimedia.org/show_bug.cgi?id=64820)
