### PR TITLE
caseInsensitive default to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ Other methods an Expert needs to provide:
 
 ## Release notes
 
+### 0.9.0 (dev)
+
+#### Breaking changes
+* `util.highlightSubstring`: `caseInsensitive` option defaults to `true` now.
+
 ### 0.8.1 (2014-11-07)
 
 #### Enhancements

--- a/ValueView.php
+++ b/ValueView.php
@@ -5,7 +5,7 @@ if ( defined( 'VALUEVIEW_VERSION' ) ) {
 	return 1;
 }
 
-define( 'VALUEVIEW_VERSION', '0.8.1' );
+define( 'VALUEVIEW_VERSION', '0.9.0-alpha' );
 
 /**
  * @deprecated

--- a/lib/util/util.highlightSubstring.js
+++ b/lib/util/util.highlightSubstring.js
@@ -18,7 +18,7 @@ this.util = this.util || {};
  * @param {string} string
  * @param {Object} [options]
  *        - {boolean} [caseInsensitive]
- *          Default: false
+ *          Default: true
  *        - {boolean} [withinString]
  *          Whether to highlight characters within the string, in contrast to at the beginning only.
  *          Default: false


### PR DESCRIPTION
I suggest to change the default behavior. Being case-insensitive should always be the default, in my opinion. Having the option to turn it off is still nice.
